### PR TITLE
Optional example should be true

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ optionalFirstName(undefined) // >> false
 optionalFirstName(null) // >> false
 optionalFirstName("") // >> false
 optionalFirstName("x") // >> { type: 'minLength', minLength: 2, value: 'x' }
-optionalFirstName("xyz") // >> false
+optionalFirstName("xyz") // >> true
 ```


### PR DESCRIPTION
Hopefully I understood correctly, but I think that the last call in the optional examples section should be true, because it's at least 3 characters in length.

``` js
optionalFirstName("xyz") // >> true
```
